### PR TITLE
No 'unlock' keyword parameter in list.append

### DIFF
--- a/po_excel_translate.py
+++ b/po_excel_translate.py
@@ -367,7 +367,7 @@ class PortableObjectFileToXLSX:
                     # Weird case
                     cell = WriteOnlyCell(self.work_sheet, value=msg.msgstr)
                     cell.font = self.font_fuzzy
-                    row.append(cell, unlock=self.unlock_message_locale)
+                    row.append(cell)
                 else:
                     # Normal case
                     row.append(


### PR DESCRIPTION
Po2xls fails when we call it with a .po file that contains a fuzzy entry. A file containing text as simple as the following will trigger the bug.

#, fuzzy
msgid "test string"
msgstr ""